### PR TITLE
Ignore space between _()

### DIFF
--- a/uncrustify.vala.cfg
+++ b/uncrustify.vala.cfg
@@ -536,6 +536,7 @@ sp_func_call_paren_empty                 = force   # ignore/add/remove/force
 # Add or remove space between the user function name and '(' on function calls
 # You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
 sp_func_call_user_paren                  = ignore   # ignore/add/remove/force
+set func_call_user _
 
 # Add or remove space between a constructor/destructor and the open paren
 sp_func_class_paren                      = force   # ignore/add/remove/force


### PR DESCRIPTION
I've added this flag because as the actual state of this configuration file when using the gettext macros I got this:

```_ ("My Text")```

After this change:
```_("My Text")```