### PR TITLE
Set indent_paren_close to 2

### DIFF
--- a/uncrustify.vala.cfg
+++ b/uncrustify.vala.cfg
@@ -198,7 +198,7 @@ indent_paren_nl                          = false    # false/true
 # 0: Indent to body level
 # 1: Align under the open paren
 # 2: Indent to the brace level
-indent_paren_close                       = 0        # number
+indent_paren_close                       = 2        # number
 
 # Controls the indent of a comma when inside a paren.If TRUE, aligns under the open paren
 indent_comma_paren                       = false    # false/true


### PR DESCRIPTION
This patch solves this issue:

![image](https://user-images.githubusercontent.com/1160365/51682649-ad1f3500-1fc6-11e9-8ab8-3f63b0e1e987.png)
