### PR TITLE
Ident switch case

### DIFF
--- a/uncrustify.vala.cfg
+++ b/uncrustify.vala.cfg
@@ -165,7 +165,7 @@ indent_relative_single_line_comments     = false    # false/true
 
 # Spaces to indent 'case' from 'switch'
 # Usually 0 or indent_columns.
-indent_switch_case                       = 0        # number
+indent_switch_case                       = indent_columns        # number
 
 # Spaces to shift the 'case' line, without affecting any other lines
 # Usually 0.


### PR DESCRIPTION
As of today the `switch` statement is not indented:

![image](https://user-images.githubusercontent.com/1160365/52165749-5a8afa80-26e3-11e9-874b-4667a69911eb.png)

This pull request changes so uncrustify indent `switch` statement like this:

![image](https://user-images.githubusercontent.com/1160365/52165759-742c4200-26e3-11e9-9231-38a5137abefc.png)

